### PR TITLE
Add FastAPI service for 3MF processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py main.py
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,48 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import JSONResponse
+import tempfile
+import zipfile
+import base64
+from typing import Dict
+
+app = FastAPI()
+
+searchKeys = [
+    'model printing time',
+    'total filament weight',
+    'enable_support',
+    'filament_type',
+    'layer_height',
+    'nozzle_diameter',
+    'sparse_infill_density',
+    'printer_model'
+]
+
+
+@app.post("/upload")
+async def uploadFile(gcodeFile: UploadFile = File(...)):
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".zip") as tmpFile:
+        tmpFile.write(await gcodeFile.read())
+        tempZipPath = tmpFile.name
+
+    plateImageBase64 = None
+    gcodeInfo: Dict[str, str] = {}
+
+    with zipfile.ZipFile(tempZipPath, 'r') as zipRef:
+        for member in zipRef.namelist():
+            lowerName = member.lower()
+            if lowerName.endswith('metadata/plate_1.png') or lowerName.endswith('metadata/plate_1.jpg'):
+                plateImageBase64 = base64.b64encode(zipRef.read(member)).decode('utf-8')
+            if lowerName.endswith('gcode_1') or lowerName.endswith('gcode/gcode_1.gcode'):
+                lines = zipRef.read(member).decode('utf-8', errors='ignore').splitlines()
+                for line in lines:
+                    for key in searchKeys:
+                        if key in line:
+                            parts = line.split('=')
+                            if len(parts) > 1:
+                                gcodeInfo[key] = parts[1].strip()
+
+    return JSONResponse({
+        'plateImage': plateImageBase64,
+        'gcodeInfo': gcodeInfo
+    })

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
## Summary
- add FastAPI endpoint that extracts metadata and gcode info from uploaded .gcode.3mf files
- include dependencies and Dockerfile for Google Cloud Run deployment

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8910f92988327a30486d9103155f9