### PR TITLE
Add FastAPI service for 3MF processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,74 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+import zipfile
+import tempfile
+import os
+from typing import Dict
+import base64
+import re
+import requests
+
+app = FastAPI()
+
+parameterMap = {
+    "modelPrintingTime": "model printing time",
+    "totalFilamentWeight": "total filament weight",
+    "enableSupport": "enable_support",
+    "filamentType": "filament_type",
+    "layerHeight": "layer_height",
+    "nozzleDiameter": "nozzle_diameter",
+    "sparseInfillDensity": "sparse_infill_density",
+    "printerModel": "printer_model"
+}
+
+
+def parseGcodeParameters(gcodeText: str) -> Dict[str, str]:
+    results = {}
+    for camelKey, pattern in parameterMap.items():
+        match = re.search(rf"{re.escape(pattern)}\s*[:=]\s*(.+)", gcodeText, re.IGNORECASE)
+        if match:
+            results[camelKey] = match.group(1).strip()
+    return results
+
+
+@app.post("/process")
+async def processFile(file: UploadFile = File(...)):
+    if not file.filename.endswith(".gcode.3mf"):
+        raise HTTPException(status_code=400, detail="Invalid file extension")
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".3mf") as temp3mf:
+        contents = await file.read()
+        temp3mf.write(contents)
+
+    tempZipPath = temp3mf.name.replace(".3mf", ".zip")
+    os.rename(temp3mf.name, tempZipPath)
+
+    results = {}
+    plateImageBase64 = None
+
+    try:
+        with zipfile.ZipFile(tempZipPath) as zipRef:
+            plateNames = [name for name in zipRef.namelist() if "metadata/plate_1" in name]
+            if plateNames:
+                with zipRef.open(plateNames[0]) as plateFile:
+                    plateImageBase64 = base64.b64encode(plateFile.read()).decode("utf-8")
+
+            gcodeNames = [name for name in zipRef.namelist() if "gcode_1" in name]
+            if gcodeNames:
+                with zipRef.open(gcodeNames[0]) as gcodeFile:
+                    gcodeText = gcodeFile.read().decode("utf-8", errors="ignore")
+                    results = parseGcodeParameters(gcodeText)
+    finally:
+        os.remove(tempZipPath)
+
+    base44Status = None
+    try:
+        base44Response = requests.get("https://base44.com", timeout=5)
+        base44Status = base44Response.status_code
+    except Exception:
+        base44Status = None
+
+    return {
+        "plate1Image": plateImageBase64,
+        "parameters": results,
+        "base44Status": base44Status
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn[standard]
+python-multipart
+requests
+zipfile36
+pytest
+flake8

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,24 @@
+from main import parseGcodeParameters
+
+def testParseGcodeParameters():
+    gcodeText = (
+        "model printing time = 123\n"
+        "total filament weight: 5.6\n"
+        "enable_support = True\n"
+        "filament_type: PLA\n"
+        "layer_height = 0.2\n"
+        "nozzle_diameter: 0.4\n"
+        "sparse_infill_density = 20\n"
+        "printer_model: MK3S"
+    )
+    result = parseGcodeParameters(gcodeText)
+    assert result == {
+        'modelPrintingTime': '123',
+        'totalFilamentWeight': '5.6',
+        'enableSupport': 'True',
+        'filamentType': 'PLA',
+        'layerHeight': '0.2',
+        'nozzleDiameter': '0.4',
+        'sparseInfillDensity': '20',
+        'printerModel': 'MK3S'
+    }


### PR DESCRIPTION
## Summary
- add FastAPI service that converts `.gcode.3mf` files to `.gcode.zip`, extracts image and parameters, and fetches Base44 status
- provide Dockerfile and requirements
- include unit test for gcode parameter parsing

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `flake8` *(fails: command not found)*
- `pytest` *(fails: No module named 'main')*


------
https://chatgpt.com/codex/tasks/task_e_68b8910f92988327a30486d9103155f9