### PR TITLE
Add FastAPI service for gcode metadata extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# FastAPI GCode Service
+
+This service exposes a FastAPI endpoint that accepts a `.gcode.3mf` file, extracts metadata, and returns a base64 image along with selected G-code values.
+
+## Running locally
+
+```bash
+pip install -r requirements.txt
+uvicorn main:apiApp --host 0.0.0.0 --port 8080
+```
+
+## Deploying to Cloud Run without a Dockerfile
+
+Google Cloud Run can build this service directly from source using [Cloud Buildpacks](https://cloud.google.com/run/docs/deploying-source-code). Ensure you are authenticated with `gcloud` and run:
+
+```bash
+gcloud run deploy gcode-service --source . --region REGION --allow-unauthenticated
+```
+
+## Endpoint
+
+`POST /process` with form-data field `gcode3mf` containing the file. The response JSON includes:
+
+- `plateImage`: base64 encoded `plate_1.png` from the `metadata` folder
+- `values`: dictionary with keys like `model printing time`, `total filament weight`, etc.
+
+## Testing
+
+```bash
+pip install -r requirements.txt pytest flake8
+flake8
+pytest
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,47 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException
+import io
+import zipfile
+import base64
+import re
+
+apiApp = FastAPI()
+
+searchKeys = [
+    'model printing time',
+    'total filament weight',
+    'enable_support',
+    'filament_type',
+    'layer_height',
+    'nozzle_diameter',
+    'sparse_infill_density',
+    'printer_model'
+]
+
+@apiApp.post('/process')
+async def processFile(gcode3mf: UploadFile = File(...)):
+    if not gcode3mf.filename.endswith('.gcode.3mf'):
+        raise HTTPException(status_code=400, detail='Invalid file extension')
+    fileData = await gcode3mf.read()
+    zipBuffer = io.BytesIO(fileData)
+    try:
+        with zipfile.ZipFile(zipBuffer) as archive:
+            try:
+                with archive.open('metadata/plate_1.png') as imageFile:
+                    plateImageBytes = imageFile.read()
+            except KeyError as exc:
+                raise HTTPException(status_code=404, detail='plate_1 not found') from exc
+            try:
+                with archive.open('gcode_1') as gcodeFile:
+                    gcodeContent = gcodeFile.read().decode('utf-8', errors='ignore')
+            except KeyError as exc:
+                raise HTTPException(status_code=404, detail='gcode_1 not found') from exc
+    except zipfile.BadZipFile as exc:
+        raise HTTPException(status_code=400, detail='Corrupted archive') from exc
+    resultValues = {}
+    for key in searchKeys:
+        pattern = re.compile(rf"{re.escape(key)}\s*=\s*(.*)", re.IGNORECASE)
+        match = pattern.search(gcodeContent)
+        if match:
+            resultValues[key] = match.group(1).strip()
+    plateImageBase64 = base64.b64encode(plateImageBytes).decode('utf-8')
+    return {'plateImage': plateImageBase64, 'values': resultValues}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+python-multipart

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+import io
+import zipfile
+import base64
+
+from main import apiApp
+
+client = TestClient(apiApp)
+
+
+def buildSample3mf():
+    memoryZip = io.BytesIO()
+    with zipfile.ZipFile(memoryZip, 'w') as archive:
+        archive.writestr(
+            'metadata/plate_1.png',
+            base64.b64decode(
+                'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADElEQVR42mP8/x8AAwMCAO/a/94AAAAASUVORK5CYII='
+            ),
+        )
+        archive.writestr(
+            'gcode_1',
+            '; model printing time = 10\n'
+            '; total filament weight = 5\n'
+            '; enable_support = True\n'
+            '; filament_type = PLA\n'
+            '; layer_height = 0.2\n'
+            '; nozzle_diameter = 0.4\n'
+            '; sparse_infill_density = 20\n'
+            '; printer_model = TestPrinter\n',
+        )
+    memoryZip.seek(0)
+    return memoryZip.getvalue()
+
+
+def test_process_file():
+    sampleData = buildSample3mf()
+    files = {
+        'gcode3mf': ('test.gcode.3mf', sampleData, 'application/octet-stream')
+    }
+    response = client.post('/process', files=files)
+    assert response.status_code == 200
+    result = response.json()
+    assert 'plateImage' in result
+    assert result['values']['model printing time'] == '10'


### PR DESCRIPTION
## Summary
- implement FastAPI endpoint to process `.gcode.3mf` archives and extract metadata
- provide Cloud Run deployment instructions without using a Dockerfile
- add unit test covering file upload and parsing behavior

## Testing
- `pip install -r requirements.txt pytest flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a6b48f6c832790b665d1d9f73d1a