### PR TITLE
Add test endpoint for API health check

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,11 @@ import re
 
 apiApp = FastAPI()
 
+
+@apiApp.get('/testRequest')
+async def testRequest():
+    return {'status': 'ok'}
+
 searchKeys = [
     'model printing time',
     'total filament weight',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,3 +42,9 @@ def test_process_file():
     result = response.json()
     assert 'plateImage' in result
     assert result['values']['model printing time'] == '10'
+
+
+def test_testRequest():
+    response = client.get('/testRequest')
+    assert response.status_code == 200
+    assert response.json() == {'status': 'ok'}


### PR DESCRIPTION
## Summary
- add /testRequest endpoint returning simple status
- add test for new endpoint

## Testing
- `flake8` *(fails: command not found and installation blocked)*
- `pytest` *(fails: httpx missing and installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68ba75a75c30832798cb6142ea355b6d