### PR TITLE
Expose container port for FastAPI app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "main:apiApp", "--host", "0.0.0.0", "--port", "80"]
+EXPOSE 8080
+
+CMD ["uvicorn", "main:apiApp", "--host", "0.0.0.0", "--port", "8080"]
 
 


### PR DESCRIPTION
## Summary
- expose port 8080 in the Dockerfile
- run FastAPI on port 8080

## Testing
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `pytest -q` *(fails: httpx missing; installation failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c1452acb4c8327b926068303e96a98