### PR TITLE
Enable CORS in FastAPI app

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,19 @@
 from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 import io
 import zipfile
 import base64
 import re
 
 apiApp = FastAPI()
+
+apiApp.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @apiApp.get('/testRequest')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -55,3 +55,15 @@ def testTestRequest():
     response = client.get('/testRequest')
     assert response.status_code == 200
     assert response.json() == {'status': 'ok'}
+
+
+def testCorsHeaders():
+    response = client.options(
+        '/testRequest',
+        headers={
+            'origin': 'http://example.com',
+            'access-control-request-method': 'GET',
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers['access-control-allow-origin'] == '*'


### PR DESCRIPTION
## Summary
- allow cross-origin requests by adding CORSMiddleware to the FastAPI app
- test that CORS headers are returned on preflight requests

## Testing
- `flake8 main.py tests/test_main.py` *(fails: command not found)*
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c26b842ffc8327af37913b8f7fedf8