### PR TITLE
Parse advanced print metadata from gcode

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import io
 import zipfile
 import base64
 import re
+import math
 
 apiApp = FastAPI()
 
@@ -23,6 +24,8 @@ async def testRequest():
 searchKeys = [
     'model printing time',
     'total filament weight [g]',
+    'total filament length [mm]',
+    'total filament volume [cm^3]',
     'enable_support',
     'filament_type',
     'layer_height',
@@ -57,5 +60,67 @@ async def processFile(gcode3mf: UploadFile = File(...)):
         match = pattern.search(gcodeContent)
         if match:
             resultValues[key] = match.group(1).strip()
+
+    objectsMatch = re.search(r'model label id:\s*([0-9,]+)', gcodeContent, re.IGNORECASE)
+    if objectsMatch:
+        ids = [s for s in objectsMatch.group(1).split(',') if s.strip()]
+        resultValues['objectsOnPlate'] = str(len(ids))
+
+    timeMatch = re.search(r'model printing time:\s*(\d+)h\s*(\d+)m\s*(\d+)s', gcodeContent, re.IGNORECASE)
+    if timeMatch:
+        hours, minutes, seconds = map(int, timeMatch.groups())
+        resultValues['printTimeSec'] = str(hours * 3600 + minutes * 60 + seconds)
+
+    weightMatch = re.search(r'total filament weight \[g\]\s*:\s*([0-9.,]+)', gcodeContent, re.IGNORECASE)
+    lengthMatch = re.search(r'total filament length \[mm\]\s*:\s*([0-9.,]+)', gcodeContent, re.IGNORECASE)
+    volumeMatch = re.search(r'total filament volume \[cm\^3\]\s*:\s*([0-9.,]+)', gcodeContent, re.IGNORECASE)
+    weights = []
+    if weightMatch:
+        weights = [float(w) for w in weightMatch.group(1).split(',') if w]
+        resultValues['filamentWeights'] = weights
+        resultValues['filamentUsedGrams'] = str(sum(weights))
+    analysis = []
+    if weights:
+        lengths = [float(l) for l in lengthMatch.group(1).split(',')] if lengthMatch else []
+        volumes = [float(v) for v in volumeMatch.group(1).split(',')] if volumeMatch else []
+        for i, w in enumerate(weights):
+            item = {'lengthMm': lengths[i] if i < len(lengths) else None,
+                    'volumeCm3': volumes[i] if i < len(volumes) else None,
+                    'weightG': w}
+            analysis.append(item)
+    resultValues['filamentAnalysis'] = analysis
+
+    changes = re.findall(r'M620\s+S\d+A', gcodeContent)
+    resultValues['filamentChanges'] = str(len(changes))
+
+    purgeLen = 0.0
+    for section in re.findall(r';\s*FLUSH_START\s*(.*?)\s*;\s*FLUSH_END', gcodeContent, re.DOTALL | re.IGNORECASE):
+        for val in re.findall(r'G1\s+E([-+]?[0-9]*\.?[0-9]+)', section):
+            purgeLen += abs(float(val))
+    diameterMatch = re.search(r'filament_diameter:\s*([0-9.,]+)', gcodeContent, re.IGNORECASE)
+    densityMatch = re.search(r'filament_density:\s*([0-9.,]+)', gcodeContent, re.IGNORECASE)
+    if purgeLen and diameterMatch and densityMatch:
+        diameter = float(diameterMatch.group(1).split(',')[0])
+        density = float(densityMatch.group(1).split(',')[0])
+        volumeMm3 = purgeLen * math.pi * (diameter / 2) ** 2
+        volumeCm3 = volumeMm3 / 1000
+        purgeGrams = volumeCm3 * density
+        resultValues['filamentPurgeGrams'] = f"{purgeGrams:.2f}"
+    else:
+        resultValues['filamentPurgeGrams'] = '0'
+
+    layerMatch = re.search(r'total layer number:\s*(\d+)', gcodeContent, re.IGNORECASE)
+    if layerMatch:
+        resultValues['totalLayers'] = layerMatch.group(1)
+
+    heightMatch = re.search(r'max_z_height:\s*([0-9.]+)', gcodeContent, re.IGNORECASE)
+    if heightMatch:
+        resultValues['maxZHeight'] = heightMatch.group(1)
+
+    resultValues.setdefault('slicerType', 'Unknown')
+    resultValues.setdefault('estimatedPowerConsumptionWh', '0')
+    resultValues.setdefault('buildPlateTemperature', '0')
+    resultValues.setdefault('hotendTemperature', '0')
+
     plateImageBase64 = base64.b64encode(plateImageBytes).decode('utf-8')
     return {'plateImage': plateImageBase64, 'values': resultValues}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,8 +19,18 @@ def buildSample3mf():
         )
         archive.writestr(
             'metadata/plate_1.gcode',
-            '; model printing time = 10\n'
-            '; total filament weight [g] = 5\n'
+            '; model printing time: 0h 0m 10s; total estimated time: 0h 0m 10s\n'
+            '; total filament length [mm] : 10.0,20.0\n'
+            '; total filament volume [cm^3] : 1.0,2.0\n'
+            '; total filament weight [g] : 1.5,2.5\n'
+            '; filament_density: 1.24\n'
+            '; filament_diameter: 1.75\n'
+            '; model label id: 1,2,3\n'
+            'M620 S0A\n'
+            'M620 S1A\n'
+            '; FLUSH_START\nG1 E10\n; FLUSH_END\n'
+            '; total layer number: 5\n'
+            '; max_z_height: 10.5\n'
             '; enable_support = True\n'
             '; filament_type = PLA\n'
             '; layer_height = 0.2\n'
@@ -39,7 +49,16 @@ def testProcessFileGcode3mf():
     assert response.status_code == 200
     result = response.json()
     assert 'plateImage' in result
-    assert result['values']['model printing time'] == '10'
+    values = result['values']
+    assert values['printTimeSec'] == '10'
+    assert values['objectsOnPlate'] == '3'
+    assert values['filamentUsedGrams'] == '4.0'
+    assert values['filamentWeights'] == [1.5, 2.5]
+    assert values['filamentAnalysis'][0]['lengthMm'] == 10.0
+    assert values['filamentChanges'] == '2'
+    assert values['filamentPurgeGrams'] != '0'
+    assert values['totalLayers'] == '5'
+    assert values['maxZHeight'] == '10.5'
 
 
 def testProcessFile3mf():


### PR DESCRIPTION
## Summary
- extend `/process` endpoint to extract object count, time, filament usage, purge data, and other metadata from gcode
- compute per-filament analysis and return defaults for future fields
- expand tests to cover new metadata parsing

## Testing
- `python -m flake8 main.py tests/test_main.py` *(fails: No module named flake8)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*
- `python -m py_compile main.py tests/test_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c27f401f548327910a43cf5433dad9