### PR TITLE
Increase object label visibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import re
 import math
 from colorsys import rgb_to_hsv
 from typing import Any, Dict, List
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, ImageFont
 import xml.etree.ElementTree as ET
 
 apiApp = FastAPI()
@@ -24,6 +24,8 @@ apiApp.add_middleware(
 @apiApp.get('/testRequest')
 async def testRequest():
     return {'status': 'ok'}
+
+testRequest.__test__ = False
 
 searchKeys = [
     'model printing time',
@@ -126,6 +128,12 @@ def drawOrderLabels(topImageBytes: bytes, rankedRegions: List[Dict[str, Any]]) -
         return topImageBytes
     topImage = Image.open(io.BytesIO(topImageBytes)).convert('RGBA')
     draw = ImageDraw.Draw(topImage)
+    imageWidth, imageHeight = topImage.size
+    baseFontSize = max(int(min(imageWidth, imageHeight) * 0.12), 24)
+    try:
+        font = ImageFont.truetype('DejaVuSans-Bold.ttf', baseFontSize)
+    except (OSError, IOError):
+        font = ImageFont.load_default()
     for region in rankedRegions:
         centroidX, centroidY = region['centroid']
         textPosition = (float(centroidX), float(centroidY))
@@ -135,7 +143,8 @@ def drawOrderLabels(topImageBytes: bytes, rankedRegions: List[Dict[str, Any]]) -
                 str(region['order']),
                 fill=(255, 255, 255, 255),
                 anchor='mm',
-                stroke_width=1,
+                font=font,
+                stroke_width=max(baseFontSize // 10, 1),
                 stroke_fill=(0, 0, 0, 255),
             )
         except TypeError:
@@ -143,6 +152,7 @@ def drawOrderLabels(topImageBytes: bytes, rankedRegions: List[Dict[str, Any]]) -
                 textPosition,
                 str(region['order']),
                 fill=(255, 255, 255, 255),
+                font=font,
             )
     outputBuffer = io.BytesIO()
     topImage.save(outputBuffer, format='PNG')


### PR DESCRIPTION
## Summary
- enlarge the rendered order numbers by picking a dynamic font size and loading a bold truetype font with stroke support
- mark the testRequest route handler as non-test so pytest does not try to execute it directly

## Testing
- python -m pytest tests/test_main.py *(fails: fastapi.UploadFile no longer accepts the legacy content_type keyword used in the existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d01e5f888327a0afd74ce8b812bd